### PR TITLE
Add English profiles

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -6,6 +6,8 @@
 title: Profile
 ---
 
+See [below](#accounts) for the English version.
+
 # アカウント
 
 - [GitHub](https://github.com/y-i)
@@ -19,7 +21,7 @@ title: Profile
 - ???
   - 2024/03-
   - チャットボットのバックエンド
-- NTT Communications
+- NTTコミュニケーションズ
   - 2017/04-2024/02
   - WebRTC PaaSのSkyWayの開発
     - ブラウザSDK、バックエンドサーバ、その他ツール・スクリプト
@@ -34,8 +36,8 @@ title: Profile
 - オンラインコミュニケーション開発ツール「SkyWay」 を支える技術 〜AlloyDB 活用例〜
   - Google Cloud Day ’23で発表
   - [セッション](https://cloudonair.withgoogle.com/events/google-cloud-day-23?talk=tok-d2-db02)
-  - [発表資料](https://speakerdeck.com/nttcom/technology-behind-the-online-communication-development-tool-skyway-utilization-example-of-alloydb
-)
+  - [発表資料](https://speakerdeck.com/nttcom/technology-behind-the-online-communication-development-tool-skyway-utilization-example-of-alloydb)
+
 ## その他記事
 
 - [NTT Communications Advent Calendar 2022](https://engineers.ntt.com/entry/2022/12/16/104148)
@@ -51,3 +53,53 @@ title: Profile
   - AtCoder 青～黄
 - ビデオゲーム
 - ボードゲーム
+
+--- 
+
+# Accounts
+
+- [GitHub](https://github.com/y-i)
+- [Speaker Deck](https://speakerdeck.com/y_i)
+- [Zenn](https://zenn.dev/y_i)
+- [Qiita](https://qiita.com/y-i)
+- [LikedIn](https://www.linkedin.com/in/yusuke-ikeda/?locale=en_US)
+
+# Career
+
+- ???
+  - 2024/03-
+  - Develop backend applications of chatbot services
+- NTT Communications
+  - 2017/04-2024/02
+  - Develop WebRTC PaaS, SkyWay
+    - SDK for web browsers, backend server applications, and other tools and scripts
+    - Reseach and implement WebRTC/MOQT
+      - [Repository](https://github.com/nttcom/moq-wasm)
+- Internship at SECOM Intelligent Systems Laboratory
+  - 2015/08-2015/09
+  - Research root certificates
+
+# Presentations
+
+- オンラインコミュニケーション開発ツール「SkyWay」 を支える技術 〜AlloyDB 活用例〜
+  - Presented at Google Cloud Day ’23 in Japanese
+  - [Session](https://cloudonair.withgoogle.com/events/google-cloud-day-23?talk=tok-d2-db02)
+  - [Presentation slides](https://speakerdeck.com/nttcom/technology-behind-the-online-communication-development-tool-skyway-utilization-example-of-alloydb)
+
+# Articles
+
+- [NTT Communications Advent Calendar 2022](https://engineers.ntt.com/entry/2022/12/16/104148)
+- [NTT Communications Advent Calendar 2023](https://engineers.ntt.com/entry/2023/12/04/064946)
+- How to use Insertable Streams at SkyWay
+  - The internal article that is the source of the following article
+    - [https://qiita.com/yusuke84/items/5a59304bf18143754cf3](https://qiita.com/yusuke84/items/5a59304bf18143754cf3)
+    - [https://qiita.com/ibuibu69/items/6da67f7dfcfbbbf2817c](https://qiita.com/ibuibu69/items/6da67f7dfcfbbbf2817c)
+
+# Hobbies & Interests
+
+- Competitive programming
+  - AtCoder (blue or yellow)
+  - Codeforces
+  - TopCoder SRM
+- Video game
+- Board game


### PR DESCRIPTION
This pull request updates the `src/index.md` file to enhance the profile content by adding an English version, expanding career details, and improving formatting. The most important changes include introducing an English section, updating career information, fixing formatting issues, and adding new sections for presentations, articles, and hobbies.

### Enhancements to profile content:

* Added an English version of the profile under a new "Accounts" section for better accessibility to non-Japanese readers. [[1]](diffhunk://#diff-c0db2152100428b43f7fb0d2c694e36549bb7dba6436e01e4ef3c7fd8f5d93c8R9-R10) [[2]](diffhunk://#diff-c0db2152100428b43f7fb0d2c694e36549bb7dba6436e01e4ef3c7fd8f5d93c8R56-R105)
* Expanded career details to include an internship at SECOM Intelligent Systems Laboratory and additional responsibilities at NTT Communications, such as WebRTC/MOQT research and implementation.

### Formatting improvements:

* Fixed a formatting issue in the link to the presentation slides by removing an unnecessary line break.

### New sections:

* Added new sections for "Presentations," "Articles," and "Hobbies & Interests," providing more comprehensive details about professional activities and personal interests.

### Localization updates:

* Updated the Japanese company name from "NTT Communications" to "NTTコミュニケーションズ" for consistency with the Japanese text.